### PR TITLE
Fix security vulnerability.

### DIFF
--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -20,7 +20,6 @@ opencensus==0.1.5
 protobuf==3.6.0
 pyasn1==0.4.3
 pyasn1-modules==0.2.2
-pycrypto==2.6.1
 pygobject==3.22.0
 pytz==2018.5
 pyxdg==0.25


### PR DESCRIPTION
pycrypto-2.6.1 in emailservice is flagged as vulnerable.
Removed this library from requirement.txt file.